### PR TITLE
Preserve whitespace in poems

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -1,0 +1,3 @@
+.poemText {
+    white-space: pre;
+}


### PR DESCRIPTION
["[White space] is an active ingredient in poetic communication"](http://www.sunoasis.com/whitespace.html), so Virgil now preserves it.

I tried both `pre` and `pre-wrap`, but I found the former to better preserve the structure of the poem. In particular, when shrinking the size of my browser to where a horizontal scroll bar was necessary:
- `pre` deferred to a scrollbar immediately
- `pre-wrap` restructured the poem by trimming leading white space before introducing a scroll bar

Perhaps this is the distinction implied [here](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) for `pre-wrap`:

> Lines are broken... as necessary to fill line boxes.
