### PR TITLE
Render blank lines of poems

### DIFF
--- a/client/src/Poem.jsx
+++ b/client/src/Poem.jsx
@@ -11,9 +11,10 @@ PoemLine.propTypes = {
 };
 
 const Poem = ({ poem }) => {
-  const poemLineNodes = poem.text.split(/\n/).map((line, index) => (
-    <PoemLine line={line} key={index} />
-  ));
+  const poemLineNodes = poem.text.split(/\n/).map((line, index) => {
+    const NBSP = '\u00A0'; // Unicode value for non-breaking space
+    return <PoemLine line={(line.trim().length === 0) ? NBSP : line} key={index} />;
+  });
   return (
     <div className="poem">
       <h2 className="poemTitle">


### PR DESCRIPTION
This change assumes that the poet does not imply meaning with various
whitespace characters. Accordingly, it represents lines of whitespace
(or blank lines) as simply `\u00A0` since empty `<div>` elements don't
occupy any visual space in the browser.
