### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+install:
+    - npm install
+    - npm install -g browserify
+    - cd client && npm install && cd ..
+script:
+    - cd client && npm run lint && npm run build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/michelmansour/virgil.svg?branch=master)](https://travis-ci.org/michelmansour/virgil)
+
 # Virgil (working title)
 A delightful way to share, discuss, and annotate poetry.
 


### PR DESCRIPTION
- Install dependencies, lint and build client code
- Add 'Build Status' image to README
- Use `.nvmrc` to specify node version [implicitly](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Using-.nvmrc)

For reference:
- [my travis page for virgil](https://travis-ci.org/drewrey/virgil)
- [instructions](http://stackoverflow.com/a/19810474) for how to configure the service hook. This will result in the green check mark on, e.g. [the list of commits page](https://github.com/drewrey/virgil/commits/travis) and [the PR page](https://github.com/drewrey/virgil/pull/1).
- I pushed another branch with an example of a [functioning build status image](https://github.com/drewrey/virgil/blob/travis_example/README.md)
