### PR TITLE
Fix ajax POST for a poem

### DIFF
--- a/client/src/PoemBox.jsx
+++ b/client/src/PoemBox.jsx
@@ -44,7 +44,8 @@ class PoemBox extends React.Component {
       url: this.props.url,
       dataType: 'json',
       type: 'POST',
-      data: poem,
+      contentType: 'application/json',
+      data: JSON.stringify(poem),
       success: (data) => {
         this.setState({ data });
       },
@@ -59,7 +60,8 @@ class PoemBox extends React.Component {
       url: this.props.url,
       dataType: 'json',
       type: 'POST',
-      data: { poems: this.state.data },
+      contentType: 'application/json',
+      data: JSON.stringify({ poems: this.state.data }),
       success: (data) => {
         this.setState({ data });
       },

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var app = express();
 var POEMS_FILE = path.join(__dirname, 'poems.json');
 
 app.use('/', express.static(path.join(__dirname, 'client/public')));
-app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.json());
 
 app.get('/', function (req, res) {
   res.send('Hello World!');


### PR DESCRIPTION
This fixes a bug where the `id` field of a poem was being converted to a
string after being sent to the server and before being saved to a file.
This behavior is fixed when both re-ordering poems and when adding a new
poem. Also, the server now uses `bodyParser.json` and so expects request
bodies to be json.
