### PR TITLE
Add routing capabilities

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "jquery": "3.1.0",
     "react": "15.3.1",
     "react-dom": "15.3.1",
+    "react-router": "2.7.0",
     "sortablejs": "1.4.2"
   },
   "devDependencies": {

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <title>PoemShare</title>
-    <link rel="stylesheet" href="css/base.css" />
+    <link rel="stylesheet" href="/css/base.css" />
   </head>
   <body>
     <div id="app"></div>
-    <script src="app.js"></script>
+    <script src="/app.js"></script>
   </body>
 </html>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,8 +1,20 @@
-import React from 'react';
-import PoemBox from './PoemBox';
+import React, { PropTypes } from 'react';
+import { IndexLink } from 'react-router';
 
-const App = () => (
-  <PoemBox url="/api/poem" pollInterval={2000} />
+const App = ({ children }) => (
+  <div>
+    <h1>Virgil</h1>
+    <ul>
+      <li><IndexLink to="/">Home</IndexLink></li>
+    </ul>
+
+    {children}
+
+  </div>
 );
+
+App.propTypes = {
+  children: PropTypes.object.isRequired,
+};
 
 export default App;

--- a/client/src/CommentListContainer.jsx
+++ b/client/src/CommentListContainer.jsx
@@ -3,16 +3,23 @@ import $ from 'jquery';
 import AddCommentForm from './AddCommentForm';
 import CommentList from './CommentList';
 
-class CommentBox extends React.Component {
+class CommentListContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { data: [] };
+    this.state = {
+      data: [],
+      intervalId: -1,
+    };
   }
 
   componentDidMount = () => {
     this.loadComments();
-    setInterval(this.loadComments, this.props.pollInterval);
-  }
+    this.state.intervalId = setInterval(this.loadComments, this.props.pollInterval);
+  };
+
+  componentWillUnmount = () => {
+    clearInterval(this.state.intervalId);
+  };
 
   loadComments = () => {
     $.ajax({
@@ -26,7 +33,7 @@ class CommentBox extends React.Component {
         console.error(this.props.url, status, err.toString());
       },
     });
-  }
+  };
 
   handleCommentSubmit = (comment) => {
     $.ajax({
@@ -53,9 +60,9 @@ class CommentBox extends React.Component {
   )
 }
 
-CommentBox.propTypes = {
+CommentListContainer.propTypes = {
   pollInterval: PropTypes.number.isRequired,
   url: PropTypes.string.isRequired,
 };
 
-export default CommentBox;
+export default CommentListContainer;

--- a/client/src/Poem.jsx
+++ b/client/src/Poem.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import CommentBox from './CommentBox';
 
 const PoemLine = ({ line }) => (
   <div className="poemLine">
@@ -25,8 +24,6 @@ const Poem = ({ poem }) => {
       <div className="poemText">
         {poemLineNodes}
       </div>
-      <CommentBox url={`/api/comments/${poem.id}`} pollInterval={2000} />
-      <hr />
     </div>
   );
 };

--- a/client/src/PoemContainer.jsx
+++ b/client/src/PoemContainer.jsx
@@ -1,0 +1,51 @@
+import React, { PropTypes } from 'react';
+import $ from 'jquery';
+import Poem from './Poem';
+import CommentListContainer from './CommentListContainer';
+
+class PoemContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      poem: {
+        id: -1,
+        title: '',
+        author: '',
+        text: '',
+      },
+      comments: [],
+    };
+  }
+
+  componentDidMount = () => {
+    this.fetchPoem();
+  };
+
+  fetchPoem = () => {
+    const fetchPoemUrl = `/api/poem/${this.props.params.poemId}`;
+    $.ajax({
+      url: fetchPoemUrl,
+      dataType: 'json',
+      cache: false,
+      success: (data) => {
+        this.setState({ poem: data });
+      },
+      error: (xhr, status, err) => {
+        console.error(fetchPoemUrl, status, err.toString());
+      },
+    });
+  };
+
+  render = () => (
+    <div className="poemContainer">
+      <Poem poem={this.state.poem} />
+      <CommentListContainer url={`/api/comments/${this.props.params.poemId}`} pollInterval={2000} />
+    </div>
+  );
+}
+
+PoemContainer.propTypes = {
+  params: PropTypes.object.isRequired,
+};
+
+export default PoemContainer;

--- a/client/src/PoemList.jsx
+++ b/client/src/PoemList.jsx
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
-import Poem from './Poem';
+import PoemSummary from './PoemSummary';
 
 const PoemList = ({ data }) => {
   const poemNodes = data.map((poem) => (
-    <Poem poem={poem} key={poem.id} />
+    <PoemSummary poem={poem} key={poem.id} />
   ));
   return (
     <div className="poemList" id="mainPoemList">
@@ -13,7 +13,7 @@ const PoemList = ({ data }) => {
 };
 
 PoemList.propTypes = {
-  data: PropTypes.arrayOf(Poem.propTypes.poem).isRequired,
+  data: PropTypes.arrayOf(PoemSummary.propTypes.poem).isRequired,
 };
 
 export default PoemList;

--- a/client/src/PoemListContainer.jsx
+++ b/client/src/PoemListContainer.jsx
@@ -1,18 +1,21 @@
 import React, { PropTypes } from 'react';
-import Sortable from 'sortablejs';
 import $ from 'jquery';
+import Sortable from 'sortablejs';
 import PoemList from './PoemList';
 import AddPoemForm from './AddPoemForm';
 
-class PoemBox extends React.Component {
+class PoemListContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { data: [] };
+    this.state = {
+      data: [],
+      intervalId: -1,
+    };
   }
 
   componentDidMount = () => {
     this.loadPoems();
-    setInterval(this.loadPoems, this.props.pollInterval);
+    this.state.intervalId = setInterval(this.loadPoems, this.props.route.pollInterval);
     const el = document.getElementById('mainPoemList');
     Sortable.create(el, {
       onUpdate: (evt) => {
@@ -25,23 +28,27 @@ class PoemBox extends React.Component {
     });
   }
 
+  componentWillUnmount = () => {
+    clearInterval(this.state.intervalId);
+  }
+
   loadPoems = () => {
     $.ajax({
-      url: this.props.url,
+      url: this.props.route.url,
       dataType: 'json',
       cache: false,
       success: (data) => {
         this.setState({ data });
       },
       error: (xhr, status, err) => {
-        console.error(this.props.url, status, err.toString());
+        console.error(this.props.route.url, status, err.toString());
       },
     });
   }
 
   handlePoemSubmit = (poem) => {
     $.ajax({
-      url: this.props.url,
+      url: this.props.route.url,
       dataType: 'json',
       type: 'POST',
       contentType: 'application/json',
@@ -50,14 +57,14 @@ class PoemBox extends React.Component {
         this.setState({ data });
       },
       error: (xhr, status, err) => {
-        console.error(this.props.url, status, err.toString());
+        console.error(this.props.route.url, status, err.toString());
       },
     });
   }
 
   savePoems = () => {
     $.ajax({
-      url: this.props.url,
+      url: this.props.route.url,
       dataType: 'json',
       type: 'POST',
       contentType: 'application/json',
@@ -66,7 +73,7 @@ class PoemBox extends React.Component {
         this.setState({ data });
       },
       error: (xhr, status, err) => {
-        console.error(this.props.url, status, err.toString());
+        console.error(this.props.route.url, status, err.toString());
       },
     });
   }
@@ -80,9 +87,11 @@ class PoemBox extends React.Component {
   )
 }
 
-PoemBox.propTypes = {
-  pollInterval: PropTypes.number.isRequired,
-  url: PropTypes.string.isRequired,
+PoemListContainer.propTypes = {
+  route: PropTypes.shape({
+    pollInterval: PropTypes.number.isRequired,
+    url: PropTypes.string.isRequired,
+  }),
 };
 
-export default PoemBox;
+export default PoemListContainer;

--- a/client/src/PoemSummary.jsx
+++ b/client/src/PoemSummary.jsx
@@ -1,0 +1,20 @@
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+
+const PoemSummary = ({ poem }) => (
+  <li>
+    <span className="poemSummaryItem">
+      <Link to={`/poem/${poem.id}`}>{poem.title}</Link> <em>by</em> {poem.author}
+    </span>
+  </li>
+);
+
+PoemSummary.propTypes = {
+  poem: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    author: PropTypes.string.isRequired,
+  }),
+};
+
+export default PoemSummary;

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { render } from 'react-dom';
+import { Router, Route, browserHistory, IndexRoute } from 'react-router';
 import App from './App';
+import PoemListContainer from './PoemListContainer';
+import PoemContainer from './PoemContainer';
 
-render(
-  <App />,
-  document.getElementById('app')
+render((
+  <Router history={browserHistory}>
+    <Route path="/" component={App}>
+      <IndexRoute component={PoemListContainer} url="/api/poem" pollInterval={2000} />
+      <Route path="/poem/:poemId" component={PoemContainer} />
+    </Route>
+  </Router>
+  ), document.getElementById('app')
 );

--- a/server.js
+++ b/server.js
@@ -11,10 +11,6 @@ const POEMS_FILE = path.join(__dirname, 'poems.json');
 app.use('/', express.static(path.join(__dirname, 'client/public')));
 app.use(bodyParser.json());
 
-app.get('/', (req, res) => {
-  res.send('Hello World!');
-});
-
 const commentFilter = (poemId) => (comment) => comment.poemId === parseInt(poemId, 10);
 
 app.get('/api/comments/:poemId', (req, res) => {
@@ -64,6 +60,18 @@ app.get('/api/poem', (req, res) => {
   });
 });
 
+app.get('/api/poem/:poemId', (req, res) => {
+  fs.readFile(POEMS_FILE, (err, data) => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    const poems = JSON.parse(data);
+    const targetPoem = poems.filter((poem) => poem.id === parseInt(req.params.poemId, 10))[0];
+    res.json(targetPoem);
+  });
+});
+
 app.post('/api/poem', (req, res) => {
   if (req.body.poems && Array.isArray(req.body.poems)) {
     const poems = req.body.poems;
@@ -98,6 +106,10 @@ app.post('/api/poem', (req, res) => {
       });
     });
   }
+});
+
+app.get('/*', (req, res) => {
+  res.sendFile(path.join(__dirname, './client/public/index.html'));
 });
 
 app.listen(3000, () => {


### PR DESCRIPTION
- Include react-router as a dependency to enable client-side routing
- Move full poem display to new client route (`/poem/:poemId`)
- Modify main poem list to show only poem titles and authors
- Add nav bar to allow navigation from a poem back to the list
- Add code to clear polling intervals of poems and comments when
  navigating away from their respective views
- Add server route to fetch individual poems
- Add catch-all route to server to support use of browser history API
- Rename some React components to better reflect their purpose
