### PR TITLE
Add print formatting for a poem

### DIFF
--- a/client/public/css/base.css
+++ b/client/public/css/base.css
@@ -1,3 +1,29 @@
 .poemText {
     white-space: pre;
 }
+
+@media print {
+    body * {
+        visibility: hidden;
+        font-family: Georgia, serif;
+        background: none;
+        color: black;
+    }
+    .poem * {
+        visibility: visible;
+    }
+    .poem {
+        height: auto;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: 15px;
+        font-size: 14px;
+        line-height: 18px;
+    }
+    .poemTitle, .byLine {
+        position: relative;
+        text-align: center;
+    }
+}

--- a/client/src/Poem.jsx
+++ b/client/src/Poem.jsx
@@ -20,7 +20,7 @@ const Poem = ({ poem }) => {
       <h2 className="poemTitle">
         {poem.title}
       </h2>
-      <p><em>by</em> {poem.author}</p>
+      <p className="byLine"><em>by</em> {poem.author}</p>
       <div className="poemText">
         {poemLineNodes}
       </div>


### PR DESCRIPTION
- Center the title and byline by targeting the .poemTitle class and the
  p tag, respectively.
- Handle multiple pages by setting .poem class's position property to
  `absolute`.
- Specify a serif font for printing.
- Set line-height larger than font-size to make physical annotations
  easier.

Tested on:
- Firefox 48
- Safari 9
- Chrome 52

Each browser has a browser-specific print style wrt page title, page url, date, etc, but the above functionality is maintained in each.
