### PR TITLE
Fix login when hitting `/login` directly 🐞

### DIFF
--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -33,6 +33,9 @@ class Login extends React.Component {
         this.setState({ error: true });
       } else {
         const { location } = this.props;
+        if (!location.state || !location.state.nextPathname) {
+          location.state = { nextPathname: '/' };
+        }
         this.context.router.replace(location.state.nextPathname);
       }
     });
@@ -61,19 +64,11 @@ class Login extends React.Component {
 }
 
 Login.propTypes = {
-  location: PropTypes.objectOf({
+  location: PropTypes.shape({
     state: PropTypes.shape({
       nextPathname: PropTypes.string,
     }),
-  }),
-};
-
-Login.defaultProps = {
-  location: {
-    state: {
-      nextPathname: '/',
-    },
-  },
+  }).isRequired,
 };
 
 Login.contextTypes = {


### PR DESCRIPTION
The next pathname of the location object is only set by the auth
redirect flow, which is not executed when the user navigates directly to
`/login`. Setting `Login.defaultProps` was an attempt to address this
edge-case, but it seems that React only performs a shallow merge of
`defaultProps` with the incoming props. Instead, we explicitly set the
pathname to `/` if `location.state.nextPathname` is unset.